### PR TITLE
Yeni bulunan cihazlar dosyanın sonuna eklenecek.

### DIFF
--- a/netprobe.py
+++ b/netprobe.py
@@ -55,9 +55,16 @@ def get_device_info(mac_address):
     return manufacturer
 
 
-def display_live_updates(target, iface):
+def display_live_updates(target, iface, output_file=None):
+    known_devices = []
     while True:
         devices = scan(target, iface)
+
+        # Save newly discovered devices
+        new_devices = [d for d in devices if d not in known_devices]
+        if new_devices and output_file:
+            save_results(new_devices, output_file)
+            known_devices.extend(new_devices)
 
         console.clear()
         table = Table(show_header=True, header_style="bold magenta")
@@ -73,7 +80,7 @@ def display_live_updates(target, iface):
 
 
 def save_results(devices, output_file):
-    with open(output_file, 'w') as f:
+    with open(output_file, 'a') as f:  # 'a' for append mode
         for device in devices:
             f.write(f"IP Address: {device['ip']}\n")
             f.write(f"MAC Address: {device['mac']}\n")
@@ -106,7 +113,7 @@ def main():
             console.print(f"\n[bold green]Results saved to: {output_file}")
 
         if live_tracking:
-            t = threading.Thread(target=display_live_updates, args=(target, iface))
+            t = threading.Thread(target=display_live_updates, args=(target, iface, output_file))
             t.daemon = True  # This makes sure the thread will exit when the main program exits
             t.start()
             while t.is_alive():  # This loop will keep the main thread running while the display thread is running


### PR DESCRIPTION
Kodunda main() fonksiyonunda cihazları dosyaya kaydetme işleminin canlı tarama özelliği devreye girmeden önce yapılmasından kaynaklanan bir hata söz konusu. Canlı tarama özelliği aktif olduğunda, her tarama döngüsünde yeni cihazları buluyor ve ekrana yazdırıyor ama bu cihazlar dosyaya kaydedilmiyor.

Bunu çözmek için dosyaya yazma işlemini display_live_updates() fonksiyonuna dahil edebiliriz. Fakat bunu yaparken dosyanın her döngüde tekrar yazılmaması için open() fonksiyonunu 'append' modunda kullanıyorum. Bu sayede yeni bulunan cihazlar dosyanın sonuna ekleniyor.

Her yeni tarama döngüsünde bulunan cihazların dosyaya eklenmesini sağlıyoruz ve known_devices listesini daha önce kaydedilen cihazları takip etmek için kullanılıyorum bu da yeni cihazların sadece bir kez kaydedilmesini sağlıyor.